### PR TITLE
avoid suspicious state from linter when nesting macros into real let or do

### DIFF
--- a/resources/claypoole/.clj-kondo/hooks/claypoole.clj
+++ b/resources/claypoole/.clj-kondo/hooks/claypoole.clj
@@ -10,7 +10,8 @@
                     (list*
                      (api/token-node token)
                      (api/list-node
-                      (list* (api/token-node 'do)
+                      (list* (api/token-node 'let*)
+                             (api/vector-node [])
                              pool
                              body))))]
       {:node (with-meta new-node
@@ -24,7 +25,8 @@
                     [(api/token-node token)
                      binding-vec-or-exprs
                      (api/list-node
-                      (list* (api/token-node 'do)
+                      (list* (api/token-node 'let*)
+                             (api/vector-node [])
                              pool
                              body))])]
       {:node (with-meta new-node

--- a/resources/slingshot/.clj-kondo/hooks/slingshot/try_plus.clj
+++ b/resources/slingshot/.clj-kondo/hooks/slingshot/try_plus.clj
@@ -9,7 +9,7 @@
             (api/list-node
              [catch (api/token-node 'Exception) (api/token-node '_e#)
               (api/list-node
-               (list* (api/token-node 'let)
+               (list* (api/token-node 'let*)
                       (api/vector-node [selector (api/token-node nil)])
                       exprs))]))
           :else catch-node)))
@@ -32,7 +32,7 @@
                        catches)))
             [body-exprs catches]))
         new-node (api/list-node
-                  [(api/token-node 'let)
+                  [(api/token-node 'let*)
                    (api/vector-node
                     [(api/token-node '&throw-context) (api/token-node nil)])
                    (api/token-node '&throw-context) ;; use throw-context to avoid warning
@@ -41,4 +41,3 @@
                      (meta node))])]
     ;; (prn (api/sexpr new-node))
     {:node new-node}))
-


### PR DESCRIPTION
Changed some macros that used `let` and `do` thus resulting in messages as in https://github.com/borkdude/clj-kondo/issues/966

I've replaced `do` with `let*` and an empty vector, which should be fine for purposes of this change, as clj-kondo doesn't see `(let* [] 1)` as a redundant `let`