### PR TITLE
A hook to support the better-cond macro and all its features.

### DIFF
--- a/better-cond/.clj-kondo/config.edn
+++ b/better-cond/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../../resources/clj-kondo.exports/clj-kondo/better-cond"]}

--- a/better-cond/README.md
+++ b/better-cond/README.md
@@ -1,0 +1,21 @@
+# Better-Cond
+
+Defines a hook that is compatible with the
+[better-cond](https://github.com/Engelberg/better-cond) library,
+which offers a practical generalization of the cond macro.
+The hook supports all the better-cond constructs in both
+keyword and symbol form.
+
+The `.clj-kondo` directory points to the
+`../../resources/clj-kondo.exports/clj-kondo/better-cond`
+directory, which contains the configuration for the hook.
+See also the docstring in the hook source file.
+
+The test file `test/clj_condo/better_cond_test.clj` can be
+run through clj-kondo on the command line to test the
+hook. For instance:
+
+```
+  clj-kondo --lang clj --lint test/clj_kondo/better_cond_test.clj
+```
+

--- a/better-cond/test/clj_kondo/better_cond_test.clj
+++ b/better-cond/test/clj_kondo/better_cond_test.clj
@@ -1,0 +1,44 @@
+(ns example.core
+   (:require [better-cond.core :as b]))
+
+(defn fn-which-may-return-falsey
+  [x]
+  [x])
+
+(defn fn-which-may-return-nil
+  [x]
+  (first x))
+
+(def a 2)
+
+(b/cond
+  (odd? a) 1
+
+  :let [a (quot a 2)]
+  ; a has been rebound to the result of (quot a 2) for the remainder
+  ; of this cond.
+
+  :when-let [x (fn-which-may-return-falsey a),
+	     y (fn-which-may-return-falsey (* 2 a))]
+  ; this when-let binds x and y for the remainder of the cond and
+  ; bails early with nil unless x and y are both truthy
+
+  :when-some [b (fn-which-may-return-nil x),
+	      c (fn-which-may-return-nil y)]
+  ; this when-some binds b and c for the reaminder of the cond and
+
+  ; bails early with nil unless b and c are both not nil
+
+  :when (seq x)
+  ; the above when bails early with nil unless (seq x) is truthy
+  ; it could have been written as: (not (seq x)) nil
+
+  :when-let [[u v] [nil nil]]
+
+  :do (println [x y u v])
+  ; A great way to put a side-effecting statement, like a println
+  ; into the middle of a cond
+
+  (odd? (+ b c)) 2
+
+  3)

--- a/resources/clj-kondo.exports/clj-kondo/better-cond/clj_kondo/better_cond.clj
+++ b/resources/clj-kondo.exports/clj-kondo/better-cond/clj_kondo/better_cond.clj
@@ -1,0 +1,92 @@
+(ns clj-kondo.better-cond
+  "A clj-kondo hook to allow linting of better-cond `cond` macro.
+  This supports better-cond version 2.0.0+. 
+
+  To use in a project, change the namespace to hooks.better-cond,
+  put this code in file .clj-kondo/hooks/better_cond.clj, and include
+  a config.edn entry in the :hooks key like:
+
+    :hooks {:analyze-call {better-cond.core/cond hooks.better-cond/cond}}
+
+  Note that the expansion of :when-let and :when-some forms currently
+  takes a shortcut that *would* lead to incorrect values in some
+  cases of restructuring during actual expansion/evaluation, e.g., 
+  :when-let [[x y] nil] would not abort the cond, though :when-let
+  [[x y] [nil nil]] would. However, for linting purposes, the current 
+  expansion approach works just fine. It seems unnecessary to do the 
+  full expansion in these cases for linting purposes, though that could
+  be done if needed."
+  (:refer-clojure :exclude [cond])
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(def better-cond-simple-keys
+  "Special constructs in better cond, either as keywords or symbols.
+  This includes those keys that are simply transformed. Note that
+  :when-let and :when-some are *not* included as better-cond allows
+  multiple bindings but clojure does not. These two must be handled
+  separately."
+  #{:let :when :do
+    'let 'when 'do})
+
+(def better-cond-complex-keys
+  "Special constructs in better cond, either as keywords or symbols.
+  This includes those keys that require a multi-step transformation.
+  For example, :when-let and :when-some get converted to a let
+  wrapping a when, wrapping the continuing cond. Note that clojure
+  does not support multiple bindings in the standard when-let and
+  when-some macros."
+  {:when-let  'identity
+   'when-let  'identity
+   :when-some 'some?
+   'when-some 'some?})
+
+(defn extract-binding-forms
+  [bindings]
+  (keep-indexed #(if (even? %1) %2) bindings))
+
+(defn process-pairs
+  "Transforms a `cond` with the clauses given as a collection of explicit pairs.
+  Handles all the special better-cond constructs as keywords or symbols.
+  Returns a rewrite-clj list-node representing the transformed code."
+  [node-pairs]
+  (loop [[[lhs rhs :as pair] & pairs] node-pairs
+         new-body [(api/token-node 'clojure.core/cond)]] ; Avoid reprocessing the cond with ns here
+    (if pair
+      (let [lhs-sexpr (api/sexpr lhs)]
+        (clojure.core/cond
+          (= 1 (count pair)) ;; better-cond allows single clause for default
+          , (api/list-node (conj new-body (api/keyword-node :else) lhs))
+          (better-cond-simple-keys lhs-sexpr) ;; Handle special better-cond constructs
+          , (api/list-node
+             (conj new-body
+                   (api/keyword-node :else)
+                   (api/list-node [(api/token-node (symbol #_"clojure.core" (name lhs-sexpr)))
+                                   rhs
+                                   (process-pairs pairs)])))
+          (better-cond-complex-keys lhs-sexpr)  ;; Multi stage constructs
+          , (api/list-node
+             (conj new-body
+                   (api/keyword-node :else)
+                   (api/list-node [(api/token-node 'let)
+                                   rhs
+                                   (api/list-node [(api/token-node 'when)
+                                                   (api/list-node    ;; ATTN: shortcut here; fine for linting
+                                                    [(api/token-node 'every?)
+                                                     (api/token-node (better-cond-complex-keys lhs-sexpr))
+                                                     (api/vector-node (->> rhs
+                                                                           api/sexpr
+                                                                           extract-binding-forms
+                                                                           (map api/token-node)))])
+                                                   (process-pairs pairs)])])))
+          :else
+          , (recur pairs (conj new-body lhs rhs))))
+      (api/list-node new-body))))
+
+(def cond
+  (fn [{:keys [:node]}]
+    (let [expr (let [args (rest (:children node))
+                     pairs (partition-all 2 args)]
+                 (process-pairs pairs))]
+      {:node (with-meta expr
+               (meta node))})))

--- a/resources/clj-kondo.exports/clj-kondo/better-cond/config.edn
+++ b/resources/clj-kondo.exports/clj-kondo/better-cond/config.edn
@@ -1,0 +1,2 @@
+{:hooks
+ {:analyze-call {better-cond.core/cond clj-kondo.better-cond/cond}}}


### PR DESCRIPTION
This is based on the hook first given [here](https://github.com/clj-kondo/clj-kondo/blob/master/corpus/.clj-kondo/hooks/better_cond.clj), but it adds support for all the better-cond features and fixes (what I think are) a  couple bugs in the original (that caused the original to fail for me). I've tested this with both clojure and clojurescript, and I included one example file for testing in this PR.

This version does take a shortcut in the expansion of :when-let and :when-some. It works fine for linting but is not exactly equivalent to the original macro when binding with restructuring. I can change this if you think it is a problem or would be beneficial for completeness. I'm happy to discuss this if what I mean here is unclear.

Thanks!