### PR TITLE
Add hooks for claypoole/upmap plus all equivalent calls in claypoole.lazy

### DIFF
--- a/claypoole/README.md
+++ b/claypoole/README.md
@@ -12,7 +12,15 @@ The example effectively remaps the following to their `clojure.core` counterpart
 | `com.climate.claypoole/completable-future` | `future`  |
 | `com.climate.claypoole/pdoseq`             | `doseq`   |
 | `com.climate.claypoole/pmap`               | `map`     |
+| `com.climate.claypoole/upmap`              | `map`     |
 | `com.climate.claypoole/pvalues`            | `pvalues` |
 | `com.climate.claypoole/upvalues`           | `pvalues` |
 | `com.climate.claypoole/pfor`               | `for`     |
 | `com.climate.claypoole/upfor`              | `for`     |
+| `com.climate.claypoole.lazy/pdoseq`        | `doseq`   |
+| `com.climate.claypoole.lazy/pmap`          | `map`     |
+| `com.climate.claypoole.lazy/upmap`         | `map`     |
+| `com.climate.claypoole.lazy/pvalues`       | `pvalues` |
+| `com.climate.claypoole.lazy/upvalues`      | `pvalues` |
+| `com.climate.claypoole.lazy/pfor`          | `for`     |
+| `com.climate.claypoole.lazy/upfor`         | `for`     |

--- a/claypoole/test/clj_kondo/claypoole_test.clj
+++ b/claypoole/test/clj_kondo/claypoole_test.clj
@@ -1,5 +1,6 @@
 (ns example
-  (:require [com.climate.claypoole :as cp]))
+  (:require
+   [com.climate.claypoole :as cp]))
 
 (def pool (cp/threadpool 8))
 (def coll [1 2 3])
@@ -23,6 +24,15 @@
            (fn [x y] (println "Mapping over" [x y]))
            coll
            coll)
+
+  ;; upmap
+  (cp/upmap 8
+            (fn [x] (println "Mapping over" x))
+            coll)
+  (cp/upmap pool
+            (fn [x y] (println "Mapping over" [x y]))
+            coll
+            coll)
 
   ;; pvalues
   (println "Parallel values"

--- a/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
+++ b/resources/clj-kondo.exports/clj-kondo/claypoole/clj_kondo/claypoole.clj
@@ -34,6 +34,7 @@
 (def completable-future (pool-and-body 'future))
 (def pdoseq (pool-with-binding-vec-or-exprs-and-body 'doseq))
 (def pmap (pool-and-body 'map))
+(def upmap (pool-and-body 'map))
 (def pvalues (pool-and-body 'pvalues))
 (def upvalues (pool-and-body 'pvalues))
 (def pfor (pool-with-binding-vec-or-exprs-and-body 'for))

--- a/resources/clj-kondo.exports/clj-kondo/claypoole/config.edn
+++ b/resources/clj-kondo.exports/clj-kondo/claypoole/config.edn
@@ -1,9 +1,18 @@
 {:linters {:claypoole {:level :warning}}
+ :lint-as {com.climate.claypoole/with-shutdown! clojure.core/let}
  :hooks   {:analyze-call {com.climate.claypoole/future             clj-kondo.claypoole/future
                           com.climate.claypoole/completable-future clj-kondo.claypoole/completable-future
                           com.climate.claypoole/pdoseq             clj-kondo.claypoole/pdoseq
                           com.climate.claypoole/pmap               clj-kondo.claypoole/pmap
+                          com.climate.claypoole/upmap              clj-kondo.claypoole/upmap
                           com.climate.claypoole/pvalues            clj-kondo.claypoole/pvalues
                           com.climate.claypoole/upvalues           clj-kondo.claypoole/upvalues
                           com.climate.claypoole/pfor               clj-kondo.claypoole/pfor
-                          com.climate.claypoole/upfor              clj-kondo.claypoole/upfor}}}
+                          com.climate.claypoole/upfor              clj-kondo.claypoole/upfor
+                          com.climate.claypoole.lazy/pdoseq        clj-kondo.claypoole/pdoseq
+                          com.climate.claypoole.lazy/pmap          clj-kondo.claypoole/pmap
+                          com.climate.claypoole.lazy/upmap         clj-kondo.claypoole/upmap
+                          com.climate.claypoole.lazy/pvalues       clj-kondo.claypoole/pvalues
+                          com.climate.claypoole.lazy/upvalues      clj-kondo.claypoole/upvalues
+                          com.climate.claypoole.lazy/pfor          clj-kondo.claypoole/pfor
+                          com.climate.claypoole.lazy/upfor         clj-kondo.claypoole/upfor}}}


### PR DESCRIPTION
Hi,

I've added a hook for 
1. upmap, which was mysteriously missing. Also added a test for it.
2. the lazy/ equivalents of those already defined for core.
3. a lint-as for `with-shutdown!` (as `clojure.core/let`).
4. Updated the README.

Let me know if you'd like me to change anything.